### PR TITLE
Move File_line into its own collect manifest

### DIFF
--- a/manifests/collect.pp
+++ b/manifests/collect.pp
@@ -1,0 +1,9 @@
+# == Resource Type: dnsmasq::collect
+#
+# This type enables collected resources
+#
+class dnsmasq::collect {
+  debug('DNSMASQ: using exported file_line resources')
+  File_line <<| tag == 'dnsmasq-host' |>>
+}
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -162,8 +162,7 @@ class dnsmasq (
   }
 
   if str2bool($exported) {
-    debug('DNSMASQ: using exported file_line resources')
-    File_line <<| tag == 'dnsmasq-host' |>>
+    include dnsmasq::collect
   } else {
     debug('DNSMASQ: bypassing exported file_line resources')
     File_line <| tag == 'dnsmasq-host' |>


### PR DESCRIPTION
Fix for masterless puppet configurations to avoid 'You cannot collect exported resources without storeconfigs being set' warnings.
